### PR TITLE
Block shop exploits

### DIFF
--- a/client/modules/cl_interaction.lua
+++ b/client/modules/cl_interaction.lua
@@ -18,7 +18,7 @@ local function OpenShopUI()
 	TriggerScreenblurFadeIn(200)
 
 	LocalPlayer.state.inShop = true
-	lib.callback.await("cloud-shop:server:InShop", false, true)
+	lib.callback.await("cloud-shop:server:InShop", false, true, LocalPlayer.state.currentShop)
 
 	ShopPeds.ApplySpeech("Generic_Hi", "Speech_Params_Force")
 end
@@ -46,7 +46,7 @@ local function CloseShopUI()
 	Functions.ToggleHud(true)
 
 	LocalPlayer.state.inShop = false
-	lib.callback.await("cloud-shop:server:InShop", false, false)
+	lib.callback.await("cloud-shop:server:InShop", false, false, nil)
 end
 local function CloseShop()
 	LocalPlayer.state.currentShop = nil

--- a/server/modules/sv_transaction.lua
+++ b/server/modules/sv_transaction.lua
@@ -49,7 +49,7 @@ local function ProcessTransaction(source, type, cartArray)
 			return false, "Invalid price for item: " .. item.name
 		end
 
-		-- Make sure the quantity is blocked from being over 100. (So cheaters can't just buy 1000+ items.)
+		-- Make sure the quantity is blocked from being over 100. (So cheaters can't just buy 1000+ items, or spawn themselves 99999999 money)
 		if item.quantity <= 0 or item.quantity > 100 then
 			return false, "Invalid quantity for item: " .. item.name
 		end

--- a/server/modules/sv_transaction.lua
+++ b/server/modules/sv_transaction.lua
@@ -15,8 +15,44 @@ local function ProcessTransaction(source, type, cartArray)
 	local accountType = type == "bank" and "bank" or "cash"
 	local totalCartPrice = 0
 
+	-- Checks if the player is actually in a shop.
+	local currentShop = inShop[source]
+	if not currentShop or not Config.Shops[currentShop] then
+		return false, "Invalid shop state."
+	end
+
+	-- Make sure the item being spawed is actually in the config/shop.
+	local shopItems = Config.Shops[currentShop].Items
+	if not shopItems then
+		return false, "Invalid shop configuration."
+	end
+
+	-- Table for valid items.
+	local validItems = {}
+	for _, item in ipairs(shopItems) do
+		validItems[item.name] = item
+	end
+
 	for i = 1, #cartArray do
 		local item = cartArray[i]
+
+		if not item.name or not item.price or not item.quantity then
+			return false, "Invalid item data."
+		end
+
+		if not validItems[item.name] then
+			return false, "Invalid item: " .. item.name
+		end
+
+		-- Blocks free items. Items shouldn't be free in shops to begin with?
+		if item.price <= 0 then
+			return false, "Invalid price for item: " .. item.name
+		end
+
+		-- Make sure the quantity is blocked from being over 100. (So cheaters can't just buy 1000+ items.)
+		if item.quantity <= 0 or item.quantity > 100 then
+			return false, "Invalid quantity for item: " .. item.name
+		end
 
 		local availableMoney = GetMoney(source, accountType)
 		local totalItemPrice = (item.price * item.quantity) or 0

--- a/server/utils/sv_shop-state.lua
+++ b/server/utils/sv_shop-state.lua
@@ -1,5 +1,9 @@
 inShop = {}
 
-lib.callback.register("cloud-shop:server:InShop", function(source, status)
-	inShop[source] = status
+lib.callback.register("cloud-shop:server:InShop", function(source, status, shopKey)
+	if status then
+		inShop[source] = shopKey
+	else
+		inShop[source] = nil
+	end
 end)


### PR DESCRIPTION
I ran into a problem where players in a server I develop for could spawn items using LUA executors from this resource. This PR changes how shop status is saved, along with other small security checks.

The client will now send the shop key when entering or exiting shops to the server side.

The server side has added validation to ensure the following:
- The player is actually purchasing the item from a shop.
- The item being purchased is actually a valid itemby checking if the item being spawned is in the Config.Shops.Items.
- Blocks any shop purchases over 100 items and blocks free items.